### PR TITLE
Add admission control and image signing validation for tekton

### DIFF
--- a/build_with_ebpf/bad_cargo/hijack-inputs.Dockerfile
+++ b/build_with_ebpf/bad_cargo/hijack-inputs.Dockerfile
@@ -1,4 +1,4 @@
-from rust:latest
+FROM rust:latest
 
 COPY "target/x86_64-unknown-linux-musl/release/bad_cargo_inputs" "/usr/local/cargo/bin/"
 RUN ["mv", "/usr/local/cargo/bin/cargo", "/tmp/cargo"]

--- a/build_with_ebpf/bad_cargo/real-cargo.Dockerfile
+++ b/build_with_ebpf/bad_cargo/real-cargo.Dockerfile
@@ -1,1 +1,1 @@
-from rust:latest
+FROM rust:latest

--- a/kubernetes/30-kyverno-setup.sh
+++ b/kubernetes/30-kyverno-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Update below if you have a different config.json you want to use.
+DOCKER_CONFIG_JSON=$HOME/.docker/config.json
+
+# Kyverno setup from the getting started tutorial:
+#   https://nirmata.com/2021/08/12/kubernetes-supply-chain-policy-management-with-cosign-and-kyverno/
+#   Installation: https://kyverno.io/docs/installation/
+
+# Create secrets for kaniko and kubernetes image pull
+kubectl create namespace kyverno --dry-run=client -o yaml | kubectl apply -f -
+
+# TODO: This should jsut be the normal secret if the kaniko task is updated to correctly use the docker config secret instead of requiring it to be hardcoded as config.json
+kubectl create secret generic secret-dockerconfigjson --type=opaque --from-file=config.json=$DOCKER_CONFIG_JSON --dry-run=client -o yaml | kubectl apply -f -
+
+# NOTE: Pull secret needs to exist in both kyverno namespace as well as the tekton task namespace (default in this case)
+kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$DOCKER_CONFIG_JSON -n kyverno  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$DOCKER_CONFIG_JSON --dry-run=client -o yaml | kubectl apply -f -
+
+# Assumes helm already installed by previous scripts
+helm repo add kyverno https://kyverno.github.io/kyverno/
+helm repo update
+helm upgrade --install kyverno-crds kyverno/kyverno-crds --namespace kyverno --create-namespace
+helm upgrade --install kyverno kyverno/kyverno -n kyverno --set extraArgs="{--webhooktimeout=15,--imagePullSecrets=regcred}"

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -33,8 +33,15 @@ extract the provenance information from a task.
 
 Script automating the [Spire] setup as defined in the getting started tutorial.
 
+## Kyverno
+
+### 30-kyverno-setup.sh
+
+Script automating the [Kyverno] setup.
+
 [Tekton]: https://tekton.dev/
 [dashboard]: https://github.com/tektoncd/dashboard
 [Chains]: https://github.com/tektoncd/chains
 [Spire]: https://spiffe.io/docs/latest/spire-about/
 [catalog]: https://github.com/tektoncd/catalog
+[Kyverno]: https://kyverno.io/docs/installation/

--- a/kubernetes/tekton-resources/demo/admission_control_verify_image.yaml
+++ b/kubernetes/tekton-resources/demo/admission_control_verify_image.yaml
@@ -1,0 +1,48 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image
+  annotations:
+    policies.kyverno.io/title: Verify Image
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/description: >-
+      Using the Cosign project, OCI images may be signed to ensure supply chain
+      security is maintained. Those signatures can be verified before pulling into
+      a cluster. This policy checks the signature of an image repo called
+      ghcr.io/kyverno/test-verify-image to ensure it has been signed by verifying
+      its signature against the provided public key. This policy serves as an illustration for
+      how to configure a similar rule and will require replacing with your image(s) and keys.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: verify-image
+      match:
+        resources:
+          kinds:
+          - Pod
+          namespaces:
+          - "default"
+      verifyImages:
+      - image: "gcr.io/tekton-releases/github.com/tektoncd/*"
+        key: |-
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnLNw3RYx9xQjXbUEw8vonX3U4+tB
+          kPnJq+zt386SCoG0ewIH5MB8+GjIDGArUULSDfjfM31Eae/71kavAUI0OA==
+          -----END PUBLIC KEY-----
+      # Change below to your public keys if you built the images yourself.
+      - image: "ghcr.io/*"
+        key: |-
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjE3xhsQUJNla1k19iDMEMS8tjHd7
+          na8/Qny/DQsiD7M4ZPjjn1MIh9Xlu34A8ir8y6rJVwFCm2YqCSfV5UCodA==
+          -----END PUBLIC KEY-----
+      - image: "ttl.sh/*"
+        key: |-
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjE3xhsQUJNla1k19iDMEMS8tjHd7
+          na8/Qny/DQsiD7M4ZPjjn1MIh9Xlu34A8ir8y6rJVwFCm2YqCSfV5UCodA==
+          -----END PUBLIC KEY-----

--- a/kubernetes/tekton-resources/demo/kaniko-with-cosign.yaml
+++ b/kubernetes/tekton-resources/demo/kaniko-with-cosign.yaml
@@ -39,8 +39,10 @@ spec:
     description: Holds the context and docker file
   - name: dockerconfig
     description: Includes a docker `config.json`
-    optional: true
+    # optional: true
     mountPath: /kaniko/.docker
+  - name: dockerconfig-cosign
+    mountPath: /root/.docker
   results:
   - name: IMAGE_DIGEST
     description: Digest of the image just built.
@@ -48,6 +50,24 @@ spec:
     description: URL of the image just built.
 
   steps:
+  # UNCOMMENT BELOW STEP TO TEST OUT SIGNED IMAGES/COMMENT OUT BELOW STEP TO TEST WITHOUT SIGNED IMAGES
+  - name: validate-parent-image-is-signed
+    workingDir: $(workspaces.source.path)
+    # Replace below with your own image based on cosign docker file.
+    # You can do this by cloning: https://github.com/sigstore/cosign/
+    # And then in the cosign directory: 
+    #   docker build . --tag ttl.sh/foo-cosign:1h -f Dockerfile
+    #   cosign sign -key k8s://tekton-chains/signing-secrets docker push ttl.sh/foo-cosign:1h
+    #   docker push ttl.sh/foo-cosign:1h
+    # You can replace the tag above with whatever you want and have access to push to.
+    # If you are using the admission controller you need to make sure the above image is signed by cosign
+    image: ghcr.io/mlieberman85/cosign
+    args:
+      - verify-dockerfile
+      - -key=https://drive.google.com/uc?export=download&id=1GYT5xnhDgY79AJ8prNyVPC52rTGdFQpg
+      - $(params.DOCKERFILE)
+    securityContext:
+      runAsUser: 0
   - name: build-and-push
     workingDir: $(workspaces.source.path)
     image: $(params.BUILDER_IMAGE)

--- a/kubernetes/tekton-resources/demo/pipeline-run.yaml
+++ b/kubernetes/tekton-resources/demo/pipeline-run.yaml
@@ -3,13 +3,18 @@ kind: PipelineRun
 metadata:
   generateName: kaniko-cargo-pipeline-run-
 spec:
+  serviceAccountName: build-bot
   pipelineRef:
     name: kaniko-cargo-pipeline
   params:
   - name: image
-    value: ttl.sh/mlieberman-kaniko-chains-demo:1h
+    # NOTE: Change me to something like  below if you want to test out without access to push mlieberman85/kaniko-chains-demo
+    # value: ttl.sh/foo-kaniko-chains-demo:1h
+    value: ghcr.io/mlieberman85/kaniko-chains-demo:latest
   workspaces:
   - name: shared-workspace
     persistentvolumeclaim:
       claimName: kaniko-source-pvc
----
+  - name: docker-secrets
+    secret:
+      secretName: secret-dockerconfigjson

--- a/kubernetes/tekton-resources/demo/pipeline.yaml
+++ b/kubernetes/tekton-resources/demo/pipeline.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   workspaces:
   - name: shared-workspace
+  - name: docker-secrets
   params:
   - name: image
     description: reference of the image to build
@@ -23,6 +24,9 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
+      # Below is required because upstream catalog version uses older image that isn't signed by tekton's private key
+    - name: gitInitImage
+      value: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.27.3
   - name: kaniko
     taskRef:
       name: kaniko
@@ -31,6 +35,10 @@ spec:
     workspaces:
     - name: source
       workspace: shared-workspace
+    - name: dockerconfig
+      workspace: docker-secrets
+    - name: dockerconfig-cosign
+      workspace: docker-secrets
     params:
     - name: IMAGE
       value: $(params.image)
@@ -67,5 +75,9 @@ spec:
     requests:
       storage: 2000Mi
 ---
-
-
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+imagePullSecrets:
+  - name: regcred


### PR DESCRIPTION
This adds image signing validation functionality for images used by
Tekton tasks as well as in the Tekton task running namespace. It also
adds image signing validation to the Kaniko build.