### PR TITLE
Add license to cargo manifest

### DIFF
--- a/oci/cosign/ocidemo/Cargo.toml
+++ b/oci/cosign/ocidemo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ocidemo"
 version = "0.1.0"
 edition = "2018"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Needed to add the license to the cargo manifest, otherwise `make cosign-attach` would fail:
```
$ RUST_BACKTRACE=1 make cosign-attach
cargo cyclonedx -f json --all
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /Users/bradbeck/.cargo/registry/src/github.com-1ecc6299db9ec823/cyclonedx-bom-0.2.0/src/license.rs:50:46
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: <cyclonedx_bom::generator::SbomGenerator as cyclonedx_bom::generator::Generator>::create_sbom
   4: cargo_cyclonedx::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
make: *** [sbom] Error 101
```