### PR TITLE
Update sget instructions

### DIFF
--- a/oci/cosign/ocidemo/Makefile
+++ b/oci/cosign/ocidemo/Makefile
@@ -7,10 +7,6 @@ TAG ?= 10m	# This is the TTL for the ttl.sh registry
 # General.
 SHELL = /bin/bash
 TOPDIR = $(shell git rev-parse --show-toplevel)
-# `sget` is a tool provided with `cosign` BUT MUST BE COMPILED MANUALLY:
-#		cd $(HOME)/projects/sigstore/cosign
-# 	go build -o sget ./cmd/sget
-SGET = $(HOME)/projects/sigstore/cosign/sget
 
 # Docker.
 DOCKERFILE = Dockerfile
@@ -60,7 +56,7 @@ cosign-attach: sbom ## Attach the SBOM to the container image
 
 .PHONY: cosign-retrieve-sbom
 cosign-retrieve-sbom: ## Retrieve and validate the SBOM
-	$(SGET) -key cosign.pub $(SBOM)
+	sget -key cosign.pub $(SBOM)
 
 # To retrieve the SBOM with crane:
 # 	crane pull ttl.sh/ocidemo:sha256-c5478895df26f9005d116864446d51e4642403c8855108c8c0f2b3519928294b.sbom pulled-sbom.tar

--- a/oci/cosign/ocidemo/README.md
+++ b/oci/cosign/ocidemo/README.md
@@ -14,7 +14,8 @@ This demo assumes the following tools are installed:
 
   * `rust` ([official](https://www.rust-lang.org/tools/install))
   * `docker` ([official](https://docs.docker.com/engine/install/))
-  * `cosign` with `sget` ([github](https://github.com/sigstore/cosign))
+  * `cosign` ([github](https://github.com/sigstore/cosign))
+  * `sget` ([github](https://github.com/sigstore/cosign/blob/main/README.md#sget))
   * `crane` ([github](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md))
   * `cyclonedx` for rust ([github](https://github.com/CycloneDX/cyclonedx-rust-cargo))
     * ⚠️ [a patch](https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/32) may


### PR DESCRIPTION
Updated the readme and makefile with info for installing `sget` based on https://github.com/sigstore/cosign/blob/main/README.md#sget